### PR TITLE
Guard Counter.inc() against negative values from ES stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ apply plugin: 'elasticsearch.testclusters'
 //    ignoreFailures = true
 //}
 
-// No unit tests in this plugin
-test.enabled = false
+// Unit tests enabled for negative counter value guard
+test.enabled = true
 
 println "Host: " + InetAddress.getLocalHost()
 println "Gradle: " + gradle.gradleVersion + " JVM: " + Jvm.current() + " Groovy: " + GroovySystem.getVersion()

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
@@ -113,6 +113,10 @@ public class PrometheusMetricsCatalog {
     }
 
     public void setCounter(String metric, double value, String... labelValues) {
+        if (value < 0) {
+            logger.warn("Skipping negative value {} for counter {}", value, metric);
+            return;
+        }
         Counter counter = (Counter) metrics.get(metric);
         counter.labels(labelValues).inc(value);
     }
@@ -171,6 +175,10 @@ public class PrometheusMetricsCatalog {
     }
 
     public void setClusterCounter(String metric, double value, String... labelValues) {
+        if (value < 0) {
+            logger.warn("Skipping negative value {} for counter {}{}", value, metricPrefix, metric);
+            return;
+        }
         Counter counter = (Counter) metrics.get(metric);
         counter.labels(getExtendedClusterLabelValues(labelValues)).inc(value);
     }
@@ -255,6 +263,10 @@ public class PrometheusMetricsCatalog {
     }
 
     public void setNodeCounter(String metric, double value, String... labelValues) {
+        if (value < 0) {
+            logger.warn("Skipping negative value {} for counter {}{}", value, metricPrefix, metric);
+            return;
+        }
         Counter counter = (Counter) metrics.get(metric);
         counter.labels(getExtendedNodeLabelValues(labelValues)).inc(value);
     }

--- a/src/test/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalogTests.java
+++ b/src/test/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalogTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright [2024] [Prometheus Exporter Contributors]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.compuscene.metrics.prometheus;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class PrometheusMetricsCatalogTests {
+
+    private PrometheusMetricsCatalog catalog;
+
+    @Before
+    public void setUp() {
+        catalog = new PrometheusMetricsCatalog("test-cluster", "test-node", "test-id", "es_");
+    }
+
+    @Test
+    public void testNodeCounterWithPositiveValue() {
+        catalog.registerNodeCounter("test_positive", "Test positive counter");
+        catalog.setNodeCounter("test_positive", 42.0);
+    }
+
+    @Test
+    public void testNodeCounterWithNegativeValueDoesNotThrow() {
+        catalog.registerNodeCounter("test_negative", "Test negative counter");
+        catalog.setNodeCounter("test_negative", -1669444.66);
+    }
+
+    @Test
+    public void testNodeCounterNegativeThenPositive() {
+        catalog.registerNodeCounter("test_mixed", "Test mixed counter");
+        catalog.setNodeCounter("test_mixed", -100.0);
+        catalog.setNodeCounter("test_mixed", 42.0);
+    }
+
+    @Test
+    public void testClusterCounterWithNegativeValueDoesNotThrow() {
+        catalog.registerClusterCounter("test_cluster_neg", "Test cluster negative counter");
+        catalog.setClusterCounter("test_cluster_neg", -999.0);
+    }
+
+    @Test
+    public void testCounterWithNegativeValueDoesNotThrow() {
+        catalog.registerCounter("test_plain_neg", "Test plain negative counter", "label1");
+        catalog.setCounter("test_plain_neg", -1.0, "value1");
+    }
+
+    @Test
+    public void testNodeCounterWithZeroValue() {
+        catalog.registerNodeCounter("test_zero", "Test zero counter");
+        catalog.setNodeCounter("test_zero", 0.0);
+    }
+}


### PR DESCRIPTION
## Problem

The `/_prometheus/metrics` endpoint intermittently returns HTTP 400 with:

```
IllegalArgumentException: Amount to increment must be non-negative.
```

This happens on clusters with high traffic and long uptime, and affects only the node where the negative stat value occurs.

## Root cause

Elasticsearch computes IO metrics as deltas between two reads of `/proc/diskstats` (`FsInfo.DeviceStats.ioTimeInMillis() = currentIOTime - previousIOTime`). When the raw counter in `/proc/diskstats` resets (e.g. after a host reboot, device-mapper operation, or disk replacement), the delta becomes negative.

The exporter creates a fresh `CollectorRegistry` on every scrape, so `Counter` starts at 0 and the absolute value from ES stats is passed to `Counter.inc()`. The Prometheus Java Client rejects negative values per the OpenMetrics spec, throwing `IllegalArgumentException` which crashes the entire metrics endpoint.

Real-world observed value on an affected node:
```
.nodes.<id>.fs.io_stats.total.io_time_in_millis: -1669444660
```

See also: [elasticsearch#52411](https://github.com/elastic/elasticsearch/issues/52411), [elasticsearch#71446](https://github.com/elastic/elasticsearch/pull/71446)

## Fix

Add a `value < 0` guard at the top of the three counter setter methods in `PrometheusMetricsCatalog.java`:

- `setCounter()`
- `setClusterCounter()`
- `setNodeCounter()`

When a negative value is encountered, it is skipped with a warning logged via the ES logger. All other metrics are exported normally. Behavior for non-negative values is unchanged.

## Tests

Enabled unit tests in `build.gradle` (`test.enabled = true`) and added `PrometheusMetricsCatalogTests.java` with 6 tests covering:

- Positive value (normal path)
- Negative value (must not throw)
- Negative followed by positive (recovery)
- Zero value (boundary)
- Cluster counter with negative value
- Plain counter with negative value

## Changes

- `build.gradle` — enable unit tests
- `PrometheusMetricsCatalog.java` — add negative value guard to 3 methods (+12 lines)
- `PrometheusMetricsCatalogTests.java` — new test file (6 tests)